### PR TITLE
Remove old versions

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -14,6 +14,11 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
+# Versions below 0.16.0 did not publish prebuilt `brig` versions
+function remove_old_versions() {
+  awk -F. '{ if( substr($1, 2, length($1)) > 0 || ($1=="v0" && $2 >= 16)) print $0; }'
+}
+
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"//;s/\",//' | sort_versions)
+versions=$(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"//;s/\",//' | remove_old_versions | sort_versions)
 echo $versions


### PR DESCRIPTION
Previously, we were listing all releases of Brigade. This resulted in a list that looked like this:

```
v0.2.0
v0.3.0
v0.5.0
v0.6.0
v0.7.0
v0.8.0
v0.9.0
v0.10.0
v0.11.0
v0.12.0
v0.13.0
v0.13.1
v0.14.0
v0.15.0
v0.16.0
v0.17.0
v0.18.0
```

However, versions for Darwin and Linux of `brig` were not published. The PR removes those old versions and only lists the ones we can easily pull binaries for.