### PR TITLE
Support other old versions

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -14,9 +14,12 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-# Versions below 0.16.0 did not publish prebuilt `brig` versions
+# Versions below 0.16.0 did not consistently publish prebuilt `brig` versions
+# This function assumes anything higher than v0.16.0 will properly publish all
+# versions.
+# See https://github.com/Azure/brigade/releases for the canonical list of binaries
 function remove_old_versions() {
-  awk -F. '{ if( substr($1, 2, length($1)) > 0 || ($1=="v0" && $2 >= 16)) print $0; }'
+  awk -F. '{ if( substr($1, 2, length($1)) > 0 || ($1=="v0" && ($2==10 || $2==12 || ($2==13 && $3==0) || $2==14 || $2 >= 16))) print $0; }'
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.


### PR DESCRIPTION
@onyxraven mentioned that some older brig releases published the binaries.

```
@onyxraven [4:36 PM]
14,13, 12, 10 all have both
```

```
root@137ee9421a05:/# asdf list-all brig
v0.10.0
v0.12.0
v0.13.0
v0.14.0
v0.16.0
v0.17.0
v0.18.0
```