### PR TITLE
brigade moved from Azure/brigade to brigadecore/brigade

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -66,7 +66,7 @@ download_url() {
     exit 1
   fi
 
-  echo "https://github.com/Azure/brigade/releases/download/${version}/brig-${platform}-amd64"
+  echo "https://github.com/brigadecore/brigade/releases/download/${version}/brig-${platform}-amd64"
 }
 
 installer "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
GitHub seems to redirect download URLs so this is just a cosmetic change until GitHub eventually stops redirecting :)