### PR TITLE
Update references to github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ that we mount through the code into the `plugins` directory for testing.
 
 ```console
 root@4f0d69e8bea6:/# asdf install brig v0.18.0
-Downloading brig from https://github.com/Azure/brigade/releases/download/v0.18.0/brig-linux-amd64 to /tmp/brig_Mi057PX/brig-v0.18.0
+Downloading brig from https://github.com/brigadecore/brigade/releases/download/v0.18.0/brig-linux-amd64 to /tmp/brig_Mi057PX/brig-v0.18.0
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100   607    0   607    0     0   1653      0 --:--:-- --:--:-- --:--:--  1649

--- a/bin/install
+++ b/bin/install
@@ -36,7 +36,7 @@ install_version() {
 
   if test "$?" != "0"; then
     rm -f "$download_path"
-    echo "ERROR: couldn't download version $version. Please ensure it's a valid release at https://github.com/Azure/brigade/releases"
+    echo "ERROR: couldn't download version $version. Please ensure it's a valid release at https://github.com/brigadecore/brigade/releases"
     exit 1
   fi
 
@@ -66,7 +66,7 @@ download_url() {
     exit 1
   fi
 
-  echo "https://github.com/Azure/brigade/releases/download/${version}/brig-${platform}-amd64"
+  echo "https://github.com/brigadecore/brigade/releases/download/${version}/brig-${platform}-amd64"
 }
 
 installer "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-releases_path=https://api.github.com/repos/Azure/brigade/releases
+releases_path=https://api.github.com/repos/brigadecore/brigade/releases
 cmd="curl -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
@@ -17,7 +17,7 @@ function sort_versions() {
 # Versions below 0.16.0 did not consistently publish prebuilt `brig` versions
 # This function assumes anything higher than v0.16.0 will properly publish all
 # versions.
-# See https://github.com/Azure/brigade/releases for the canonical list of binaries
+# See https://github.com/brigadecore/brigade/releases for the canonical list of binaries
 function remove_old_versions() {
   awk -F. '{ if( substr($1, 2, length($1)) > 0 || ($1=="v0" && ($2==10 || $2==12 || ($2==13 && $3==0) || $2==14 || $2 >= 16))) print $0; }'
 }


### PR DESCRIPTION
The source of brig releases appears to have moved from https://github.com/Azure/brigade to https://github.com/brigadecore/brigade