### PR TITLE
Deal with existing v prefixes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,3 +34,10 @@ jobs:
         with:
           version: v1.4.0
           command: brig version
+      - name: asdf_plugin_test_without_v_prefix
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: asdf-vm/actions/plugin-test@v1.0.0
+        with:
+          version: 1.4.0
+          command: brig version

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,3 +27,10 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v1.0.0
         with:
           command: brig version
+      - name: asdf_plugin_test_with_v_prefix
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: asdf-vm/actions/plugin-test@v1.0.0
+        with:
+          version: v1.4.0
+          command: brig version

--- a/bin/install
+++ b/bin/install
@@ -14,7 +14,10 @@ installer() {
 
 install_version() {
   # Note that we're adding back the 'v' tag prefix.
-  local version=v$1
+  local version=$1
+  if [[ ! $version =~ v ]]; then
+    version=v$1
+  fi
   local install_path=$2
 
   local bin_install_path


### PR DESCRIPTION
Made a mistake in the prior fix that would have broken existing automation or installations that _include_ the `v` version prefix.